### PR TITLE
Update class_filedialog.rst for configuration dependency clarity.

### DIFF
--- a/classes/class_filedialog.rst
+++ b/classes/class_filedialog.rst
@@ -451,7 +451,7 @@ If ``true``, the dialog will show hidden files.
 - |void| **set_use_native_dialog**\ (\ value\: :ref:`bool<class_bool>`\ )
 - :ref:`bool<class_bool>` **get_use_native_dialog**\ (\ )
 
-If ``true``, :ref:`access<class_FileDialog_property_access>` is set to :ref:`ACCESS_FILESYSTEM<class_FileDialog_constant_ACCESS_FILESYSTEM>`, and it is supported by the current :ref:`DisplayServer<class_DisplayServer>`, OS native dialog will be used instead of custom one.
+If ``true``, **and** :ref:`access<class_FileDialog_property_access>` is **also** set to :ref:`ACCESS_FILESYSTEM<class_FileDialog_constant_ACCESS_FILESYSTEM>`, **and** it is **also** supported by the current :ref:`DisplayServer<class_DisplayServer>`, OS native dialog will be used instead of custom one.
 
 \ **Note:** On macOS, sandboxed apps always use native dialogs to access host filesystem.
 


### PR DESCRIPTION
The changes of this PR are an update for the `FileDialog` class reference.

I have used `FileDialog` in my project with the `use_native_dialog` set to true, but it's not working. The issue is that the `access` property **needs** to be set to `ACCESS_FILESYSTEM` instead of **will** automatically set to true. 

The dependency of this property which in the documentation is described as :

"If true, `access` is set to `ACCESS_FILESYSTEM`, and it is supported by the current `DisplayServer`"

This sentence is too long to read which easily causes misunderstanding like I did, so I modified it to:

"If true, **and** `access` is **also** set to `ACCESS_FILESYSTEM`, **and** it is **also** supported by the current `DisplayServer`"

Personally, this is clearer for its **dependency**, and it doesn't repeat "and" and "also" too many times. This is my idea, I'd like to talk with you about any better ideas to help clarify things.